### PR TITLE
Relay all messages regardless of order

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,58 +12,74 @@ mod proxy_socket;
 
 use proxy_socket::ProxySocket;
 
-const BUFFER_SIZE: usize = 1024 ^ 2;	 // 1024 ^ 2 is the maximum
+const BUFFER_SIZE: usize = 1024 ^ 2; // 1024 ^ 2 is the maximum
 
 fn valid_length(length: usize) -> bool {
     length > 0 && length <= BUFFER_SIZE
 }
 
-fn read_header() -> usize {
+// Read a header (message size) from stdin (e.g.: from the browser).
+fn read_header() -> Result<usize> {
     let stdin = stdin();
     let mut buf = vec![0; 4];
     let mut handle = stdin.lock();
 
-    handle.read_exact(&mut buf).unwrap();
-    NativeEndian::read_u32(&buf).try_into().unwrap()
+    handle.read_exact(&mut buf)?;
+
+    NativeEndian::read_u32(&buf)
+        .try_into()
+        .map_err(|err| Error::new(ErrorKind::InvalidData, err))
 }
 
-fn read_body<T: Read + Write>(length: usize, socket: &mut ProxySocket<T>) {
+// Handle a whole request/response cycle
+//
+// Read a message body from stdin (e.g.: from the browser), and echo it back to the browser's
+// socket. Then await a response from the socket and relay that back to the browser.
+fn read_body<T: Read + Write>(length: usize, socket: &mut ProxySocket<T>) -> Result<()> {
     let mut buffer = vec![0; length];
     let stdin = stdin();
     let mut handle = stdin.lock();
 
-    if handle.read_exact(&mut buffer).is_ok() && valid_length(length) {
-        socket.write_all(&buffer).unwrap();
-        socket.flush().unwrap();
-        read_response(socket);
+    handle.read_exact(&mut buffer)?;
+
+    if valid_length(length) {
+        socket.write_all(&buffer)?;
+        socket.flush()?;
+        read_response(socket)?;
     }
+
+    Ok(())
 }
 
-fn read_response<T: Read>(socket: &mut ProxySocket<T>) {
+// Read a response (from KP's socket) and echo it back to the browser.
+fn read_response<T: Read>(socket: &mut ProxySocket<T>) -> Result<()>{
     let mut buf = vec![0; BUFFER_SIZE];
     if let Ok(len) = socket.read(&mut buf) {
-        write_response(&buf[0..len]);
+        write_response(&buf[0..len])?;
     }
+
+    Ok(())
 }
 
-fn write_response(buf: &[u8]) {
+// Write a response to stdout (e.g.: to the browser).
+fn write_response(buf: &[u8]) -> Result<()> {
     let stdout = stdout();
     let mut out = stdout.lock();
 
-    out.write_u32::<NativeEndian>(buf.len() as u32).unwrap();
-    out.write_all(buf).unwrap();
-    out.flush().unwrap();
+    out.write_u32::<NativeEndian>(buf.len() as u32)?;
+    out.write_all(buf)?;
+    out.flush()?;
+
+    Ok(())
 }
 
 fn main() {
     let mut socket = proxy_socket::connect(BUFFER_SIZE).unwrap();
 
     // Start thread for user input reading
-    let ui = thread::spawn(move || {
-        loop {
-            let length = read_header();
-            read_body(length, &mut socket);
-        }
+    let ui = thread::spawn(move || loop {
+        let length = read_header().unwrap();
+        read_body(length, &mut socket).unwrap();
     });
 
     let _ui_res = ui.join().unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,8 +60,11 @@ fn main() -> Result<()> {
     let mut socket = proxy_socket::connect(BUFFER_SIZE)?;
     let mut socket_clone = socket.try_clone()?;
 
-    thread::spawn(move || stdin_to_socket(&mut socket));
-    socket_to_stdout(&mut socket_clone)?;
+    thread::scope(|s| {
+        // When either of these panic, we exit immediately.
+        s.spawn(move || stdin_to_socket(&mut socket).unwrap());
+        s.spawn(move || socket_to_stdout(&mut socket_clone).unwrap());
+    });
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,12 +1,12 @@
 extern crate byteorder;
-extern crate nix;
 #[cfg(windows)]
 extern crate named_pipe;
+extern crate nix;
 
-use std::convert::TryInto;
-use std::io::{self, Read, Write};
-use std::thread;
 use byteorder::{ByteOrder, NativeEndian, WriteBytesExt};
+use std::convert::TryInto;
+use std::io::{stdin, stdout, Error, ErrorKind, Read, Result, Write};
+use std::thread;
 
 mod proxy_socket;
 
@@ -19,7 +19,7 @@ fn valid_length(length: usize) -> bool {
 }
 
 fn read_header() -> usize {
-    let stdin = io::stdin();
+    let stdin = stdin();
     let mut buf = vec![0; 4];
     let mut handle = stdin.lock();
 
@@ -29,7 +29,7 @@ fn read_header() -> usize {
 
 fn read_body<T: Read + Write>(length: usize, socket: &mut ProxySocket<T>) {
     let mut buffer = vec![0; length];
-    let stdin = io::stdin();
+    let stdin = stdin();
     let mut handle = stdin.lock();
 
     if handle.read_exact(&mut buffer).is_ok() && valid_length(length) {
@@ -47,7 +47,7 @@ fn read_response<T: Read>(socket: &mut ProxySocket<T>) {
 }
 
 fn write_response(buf: &[u8]) {
-    let stdout = io::stdout();
+    let stdout = stdout();
     let mut out = stdout.lock();
 
     out.write_u32::<NativeEndian>(buf.len() as u32).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,28 +43,33 @@ fn socket_to_stdout<T: Read + Write>(socket: &mut ProxySocket<T>) -> Result<()> 
     let mut out = stdout().lock();
     let mut buf = [0; BUFFER_SIZE];
 
-    while let Ok(len) = socket.read(&mut buf) {
-        // If a message is larger than the maximum, ignore it entirely. These are disallowed
-        // by the browser anyway, so sending one would be a protocol violation.
-        if len <= BUFFER_SIZE {
-            out.write_u32::<NativeEndian>(len as u32)?;
-            out.write_all(&buf[..len])?;
-            out.flush()?;
+    loop {
+        if let Ok(len) = socket.read(&mut buf) {
+            // If a message is larger than the maximum, ignore it entirely. These are disallowed
+            // by the browser anyway, so sending one would be a protocol violation.
+            if len <= BUFFER_SIZE {
+                out.write_u32::<NativeEndian>(len as u32)?;
+                out.write_all(&buf[..len])?;
+                out.flush()?;
+            };
+        } else {
+            // TOOD: is the socket is closed, we should try to reconnect.
+
+            return Err(Error::from(ErrorKind::BrokenPipe));
         }
     }
-
-    Err(Error::from(ErrorKind::BrokenPipe))
 }
 
 fn main() -> Result<()> {
     let mut socket = proxy_socket::connect(BUFFER_SIZE)?;
     let mut socket_clone = socket.try_clone()?;
 
-    thread::scope(|s| {
-        // When either of these panic, we exit immediately.
-        s.spawn(move || stdin_to_socket(&mut socket).unwrap());
-        s.spawn(move || socket_to_stdout(&mut socket_clone).unwrap());
-    });
+    thread::spawn(move || socket_to_stdout(&mut socket_clone).unwrap());
+
+    // If stdin is closed, that means that Firefox has exited, so we exit too.
+    // If the socket is closed, this will (eventually) fail too, however, this can later be
+    // refactored to reconnect the underlying ProxySocket.
+    stdin_to_socket(&mut socket).unwrap();
 
     Ok(())
 }

--- a/src/proxy_socket.rs
+++ b/src/proxy_socket.rs
@@ -49,7 +49,7 @@ fn get_socket_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     if !cfg!(target_os = "macos") {
-        if let Ok(dir) = env::var("XDG_RUNTIME_DIR")  {
+        if let Ok(dir) = env::var("XDG_RUNTIME_DIR") {
             let xdg_runtime_dir: PathBuf = dir.into();
 
             // Sandbox-friendly path.
@@ -79,8 +79,9 @@ pub fn connect(buffer_size: usize) -> io::Result<ProxySocket<UnixStream>> {
         .find_map(|dir| UnixStream::connect(dir.join(socket_name)).ok())
         .ok_or_else(|| io::Error::from(io::ErrorKind::NotFound))?;
 
-    socket::setsockopt(s.as_raw_fd(), SndBuf, &buffer_size).expect("setsockopt for SndBuf failed");
-    socket::setsockopt(s.as_raw_fd(), RcvBuf, &buffer_size).expect("setsockopt for RcvBuf failed");
+    socket::setsockopt(s.as_raw_fd(), SndBuf, &buffer_size)?;
+    socket::setsockopt(s.as_raw_fd(), RcvBuf, &buffer_size)?;
+
     let timeout: Option<Duration> = Some(Duration::from_secs(1));
     s.set_read_timeout(timeout)?;
     Ok(ProxySocket { inner: s })


### PR DESCRIPTION
The existing implementation expects alternating messages from each
source. If either side delivered two consecutive messages, these were
not handled properly and communication ended up out-of-sync.

This new approach runs two threads, each one handling data in one
direction.

I replaced the BUFFER_SIZE because the caret (^) symbol means bitwise or
in rust, so:

    1024 ^ 2 = 1026

The read timeout has been removed, since we now actually WANT to block
indefinitely if there is no traffic in a given direction.

Fixes: https://github.com/varjolintu/keepassxc-proxy-rust/issues/13
Fixes: https://github.com/varjolintu/keepassxc-proxy-rust/issues/14
Closes: https://github.com/varjolintu/keepassxc-proxy-rust/pull/16