### PR TITLE
Update build static instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Then build with
 RUSTFLAGS='-C link-arg=-s' cargo build --release --target x86_64-unknown-linux-musl
 ```
 
+If you want to use keepass-proxy-rust in Flatpak, or on another system (cross-compiling or different linker), use this instead:
+
+```bash
+RUSTFLAGS='-C link-arg=-s -Clink-self-contained=y -Clinker=rust-lld' cargo build --release --target x86_64-unknown-linux-musl
+```
+
 (see [Stackoverflow](https://stackoverflow.com/a/59766875/487503))
 ## Copyright
 


### PR DESCRIPTION
this help when using a non standard linker (like the case when using rustup from brew)

when compiling without it, this is what happens (this is with the linker options present in the readme)

```
./target/x86_64-unknown-linux-musl/release/keepassxc-proxy: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /home/linuxbrew/.linuxbrew/lib/ld.so, not stripped
```

when executing in the librewolf flatpak, it gives this error

```
sh: ./.librewolf/native-messaging-hosts/keepassxc-proxy: cannot execute: required file not found
```

when these linker options are passed, it forces the executable to include it's own linker, making it truly self contained

```
./target/x86_64-unknown-linux-musl/release/keepassxc-proxy: ELF 64-bit LSB pie executable, x86-64, version 1 (SYSV), static-pie linked, stripped
```

this makes the compiled executable work on my machine, 
![image](https://github.com/user-attachments/assets/c50a03f3-cb66-46f3-8d55-169ad3e38d39)
